### PR TITLE
Functioning pytorch-3dunet training

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -54,11 +54,14 @@ class BraTS2020Dataset(Dataset):
                 for extension in self.NONMASK_EXTENSIONS
             )
         )
-        # Normalize to be in 0, 1
-        img = np.stack((img - img.min()) / (img.max() - img.min()) for img in raw_imgs)
+        # Normalize to be in [0, 1] and use float32 for groupnorm compatibility
+        img = np.stack(
+            ((img - img.min()) / (img.max() - img.min()) for img in raw_imgs),
+        )
         image_tensor = torch.as_tensor(
             # N x W x H x C to N x C x H x W
             np.moveaxis(img, (0, 1, 2, 3), (0, 3, 2, 1)),
+            dtype=torch.get_default_dtype(),  # Match pytorch-3dunet internals
             device=self._device,
         )
         if not self.train:

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -54,10 +54,8 @@ class BraTS2020Dataset(Dataset):
                 for extension in self.NONMASK_EXTENSIONS
             )
         )
-        # Normalize to be in [0, 1] and use float32 for groupnorm compatibility
-        img = np.stack(
-            ((img - img.min()) / (img.max() - img.min()) for img in raw_imgs),
-        )
+        # Normalize to be in [0, 1]
+        img = np.stack((img - img.min()) / (img.max() - img.min()) for img in raw_imgs)
         image_tensor = torch.as_tensor(
             # N x W x H x C to N x C x H x W
             np.moveaxis(img, (0, 1, 2, 3), (0, 3, 2, 1)),
@@ -75,6 +73,7 @@ class BraTS2020Dataset(Dataset):
         return image_tensor, torch.as_tensor(
             # N x W x H x C to N x C x H x W
             np.moveaxis(np.stack((wt, tc, et)), (0, 1, 2, 3), (0, 3, 2, 1)),
+            dtype=torch.get_default_dtype(),  # Match pytorch-3dunet internals
             device=self._device,
         )
 

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -4,6 +4,7 @@ import torch
 from pytorch3dunet.unet3d.losses import BCEDiceLoss
 from pytorch3dunet.unet3d.model import UNet3D
 from pytorch3dunet.unet3d.trainer import UNetTrainer
+from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
 
 from data.loaders import TRAIN_DS_KWARGS, VAL_DS_KWARGS, BraTS2020Dataset
@@ -13,17 +14,17 @@ NUM_SCANS_PER_EXAMPLE = 4
 NUM_CLASSES = 3
 INITIAL_CONV_OUT_CHANNELS = 24
 
-data_loaders: dict[Literal["train", "val"], DataLoader] = {
-    "train": DataLoader(BraTS2020Dataset(**TRAIN_DS_KWARGS)),
-    "val": DataLoader(BraTS2020Dataset(**VAL_DS_KWARGS)),
-}
-
 model = UNet3D(
     in_channels=NUM_SCANS_PER_EXAMPLE,
     out_channels=NUM_CLASSES,
     final_sigmoid=True,
     f_maps=INITIAL_CONV_OUT_CHANNELS,
+    num_groups=6,
 )
+data_loaders: dict[Literal["train", "val"], DataLoader] = {
+    "train": DataLoader(BraTS2020Dataset(**TRAIN_DS_KWARGS)),
+    "val": DataLoader(BraTS2020Dataset(**VAL_DS_KWARGS)),
+}
 trainer = UNetTrainer(
     model,
     optimizer=torch.optim.Adam(model.parameters(), lr=5e-4),
@@ -34,4 +35,6 @@ trainer = UNetTrainer(
     checkpoint_dir=str(ZOO_FOLDER / "logs"),
     max_num_epochs=5,
     max_num_iterations=1000,  # Max number of batches per epoch
+    tensorboard_formatter=DefaultTensorboardFormatter(),
 )
+trainer.fit()


### PR DESCRIPTION
- Fixes `BraTS2020Dataset` to have correct `dtype` that work with `pytorch-3dunet`
- Adds `trainer.fit()`
- Fixes group size incompatibility issue and missing tensorboard formatter