### PR TITLE
Lightweight training and training docs

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -1,8 +1,10 @@
 import itertools
 import os
+from enum import IntEnum
 
 import nibabel as nib
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import torch
 from torch.utils.data import Dataset
@@ -10,10 +12,43 @@ from torch.utils.data import Dataset
 from data import BRATS_2020_TRAINING_FOLDER, BRATS_2020_VALIDATION_FOLDER
 
 
+class BraTS2020Classes(IntEnum):
+    """Classes found in the BraTS 2020 dataset."""
+
+    NON_TUMOR = 0
+    NON_ENHANCING_TUMOR_CORE = 1  # Aka NCR/NET (neuroendocrine tumor)
+    # Swelling around the tumor
+    PERITUMORAL_EDEMA = 2  # Aka ED
+    # Gadolinium enhancing
+    GD_ENHANCING_TUMOR = 4  # Aka ET
+
+    @classmethod
+    def to_whole_tumor(cls, mask: npt.NDArray[int]) -> np.ndarray:
+        """Convert a mask to whole tumor (WT)."""
+        return mask >= cls.NON_TUMOR.value
+
+    @classmethod
+    def to_tumor_core(cls, mask: npt.NDArray[int]) -> np.ndarray:
+        """Convert a mask to tumor core (TC)."""
+        return np.logical_or(
+            mask == cls.NON_ENHANCING_TUMOR_CORE.value,
+            mask == cls.GD_ENHANCING_TUMOR.value,
+        )
+
+    @classmethod
+    def to_enhancing_tumor(cls, mask: npt.NDArray[int]) -> np.ndarray:
+        """Convert a mask to enhancing tumor (ET)."""
+        return mask == cls.GD_ENHANCING_TUMOR.value
+
+
 class BraTS2020Dataset(Dataset):
     """Map-style dataset for BraTS 2020."""
 
     TARGET_COLUMN = "BraTS_2020_subject_ID"
+    # flair = T2-weighted Fluid Attenuated Inversion Recovery (T2-FLAIR)
+    # t1 = native T1-weighted (T1)
+    # t1ce = post-contrast T1-weighted (T1Gd)
+    # t2 = T2-weighted (T2)
     NONMASK_EXTENSIONS = ["_flair.nii", "_t1.nii", "_t1ce.nii", "_t2.nii"]
     MASK_EXTENSION = "_seg.nii"
 
@@ -43,8 +78,6 @@ class BraTS2020Dataset(Dataset):
         )
         return os.path.join(image_folder, os.path.basename(image_folder) + extension)
 
-    WT, TC, ET = 1, 2, 4
-
     def __getitem__(self, index: int) -> tuple[torch.Tensor, ...]:
         """Get (images, masks) if training, otherwise (images,)."""
         raw_imgs = (
@@ -67,9 +100,9 @@ class BraTS2020Dataset(Dataset):
         mask = np.asarray(
             nib.load(self.get_full_path(index, self.MASK_EXTENSION)).dataobj,
         )
-        wt = mask >= self.WT
-        tc = np.logical_and(mask != self.TC, mask >= self.WT)
-        et = mask >= self.ET
+        wt = BraTS2020Classes.to_whole_tumor(mask)
+        tc = BraTS2020Classes.to_tumor_core(mask)
+        et = BraTS2020Classes.to_enhancing_tumor(mask)
         return image_tensor, torch.as_tensor(
             # N x W x H x C to N x C x H x W
             np.moveaxis(np.stack((wt, tc, et)), (0, 1, 2, 3), (0, 3, 2, 1)),

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -13,7 +13,11 @@ from data import BRATS_2020_TRAINING_FOLDER, BRATS_2020_VALIDATION_FOLDER
 
 
 class BraTS2020Classes(IntEnum):
-    """Classes found in the BraTS 2020 dataset."""
+    """
+    Classes found in the BraTS 2020 dataset.
+
+    SEE: https://www.med.upenn.edu/cbica/brats2020/data.html
+    """
 
     NON_TUMOR = 0
     NON_ENHANCING_TUMOR_CORE = 1  # Aka NCR/NET (neuroendocrine tumor)

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -87,7 +87,7 @@ class BraTS2020Dataset(Dataset):
         self.skip_slices = skip_slices
 
     def __len__(self) -> int:
-        return len(self._names) - 2 * self.skip_slices
+        return len(self._names)
 
     def get_full_path(self, index: int, extension: str) -> str:
         image_folder = os.path.join(

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 from enum import IntEnum
 
@@ -144,13 +143,16 @@ TRAIN_DS_KWARGS = {
 VAL_DS_KWARGS = {
     "data_folder_path": BRATS_2020_VALIDATION_FOLDER,
     "mapping_csv_name": "name_mapping_validation_data.csv",
+    "train": False,
 }
 
 
 def main() -> None:
     train_ds = BraTS2020Dataset(**TRAIN_DS_KWARGS)
+    for images, targets in train_ds:  # noqa: B007
+        _ = 0
     val_ds = BraTS2020Dataset(**VAL_DS_KWARGS)
-    for images, targets in itertools.chain(train_ds, val_ds):  # noqa: B007
+    for images in val_ds:  # noqa: B007
         _ = 0
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -26,3 +26,4 @@ mypy
 pip-tools
 pre-commit
 pylint[spelling]
+torchsummary

--- a/requirements.in
+++ b/requirements.in
@@ -26,4 +26,4 @@ mypy
 pip-tools
 pre-commit
 pylint[spelling]
-torchsummary
+torchinfo  # Printing model summary

--- a/requirements.txt
+++ b/requirements.txt
@@ -266,6 +266,8 @@ tomlkit==0.11.8
     # via pylint
 torch==2.0.1
     # via -r requirements.in
+torchsummary==1.5.1
+    # via -r requirements.in
 tqdm==4.65.0
     # via kaggle
 traitlets==5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -266,7 +266,7 @@ tomlkit==0.11.8
     # via pylint
 torch==2.0.1
     # via -r requirements.in
-torchsummary==1.5.1
+torchinfo==1.8.0
     # via -r requirements.in
 tqdm==4.65.0
     # via kaggle

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -7,21 +7,16 @@ from pytorch3dunet.unet3d.trainer import UNetTrainer
 from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
 
-from data.loaders import (
-    TRAIN_DS_KWARGS,
-    VAL_DS_KWARGS,
-    BraTS2020Classes,
-    BraTS2020Dataset,
-)
+from data.loaders import TRAIN_DS_KWARGS, VAL_DS_KWARGS, BraTS2020Dataset
 from unet_zoo import ZOO_FOLDER
 
 NUM_SCANS_PER_EXAMPLE = len(BraTS2020Dataset.NONMASK_EXTENSIONS)
-NUM_CLASSES = len(BraTS2020Classes)
+MASK_COUNT = 3  # WT, TC, ET
 INITIAL_CONV_OUT_CHANNELS = 24
 
 model = UNet3D(
     in_channels=NUM_SCANS_PER_EXAMPLE,
-    out_channels=NUM_CLASSES,
+    out_channels=MASK_COUNT,
     final_sigmoid=True,
     f_maps=INITIAL_CONV_OUT_CHANNELS,
     num_groups=6,

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -22,8 +22,8 @@ model = UNet3D(
     num_groups=6,
 )
 data_loaders: dict[Literal["train", "val"], DataLoader] = {
-    "train": DataLoader(BraTS2020Dataset(**TRAIN_DS_KWARGS)),
-    "val": DataLoader(BraTS2020Dataset(**VAL_DS_KWARGS)),
+    "train": DataLoader(BraTS2020Dataset(skip_slices=5, **TRAIN_DS_KWARGS)),
+    "val": DataLoader(BraTS2020Dataset(skip_slices=5, **VAL_DS_KWARGS)),
 }
 trainer = UNetTrainer(
     model,

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -7,11 +7,16 @@ from pytorch3dunet.unet3d.trainer import UNetTrainer
 from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
 
-from data.loaders import TRAIN_DS_KWARGS, VAL_DS_KWARGS, BraTS2020Dataset
+from data.loaders import (
+    TRAIN_DS_KWARGS,
+    VAL_DS_KWARGS,
+    BraTS2020Classes,
+    BraTS2020Dataset,
+)
 from unet_zoo import ZOO_FOLDER
 
-NUM_SCANS_PER_EXAMPLE = 4
-NUM_CLASSES = 3
+NUM_SCANS_PER_EXAMPLE = len(BraTS2020Dataset.NONMASK_EXTENSIONS)
+NUM_CLASSES = len(BraTS2020Classes)
 INITIAL_CONV_OUT_CHANNELS = 24
 
 model = UNet3D(
@@ -34,7 +39,8 @@ trainer = UNetTrainer(
     loaders=data_loaders,
     checkpoint_dir=str(ZOO_FOLDER / "logs"),
     max_num_epochs=5,
-    max_num_iterations=1000,  # Max number of batches per epoch
+    max_num_iterations=1000,  # Defeat max number of batches per epoch
     tensorboard_formatter=DefaultTensorboardFormatter(),
+    skip_train_validation=True,
 )
 trainer.fit()

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -14,6 +14,13 @@ NUM_SCANS_PER_EXAMPLE = len(BraTS2020Dataset.NONMASK_EXTENSIONS)
 MASK_COUNT = 3  # WT, TC, ET
 INITIAL_CONV_OUT_CHANNELS = 24
 
+
+def infer_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")  # Current CUDA device
+    return torch.device("cpu")
+
+
 model = UNet3D(
     in_channels=NUM_SCANS_PER_EXAMPLE,
     out_channels=MASK_COUNT,
@@ -22,8 +29,12 @@ model = UNet3D(
     num_groups=6,
 )
 data_loaders: dict[Literal["train", "val"], DataLoader] = {
-    "train": DataLoader(BraTS2020Dataset(skip_slices=5, **TRAIN_DS_KWARGS)),
-    "val": DataLoader(BraTS2020Dataset(skip_slices=5, **VAL_DS_KWARGS)),
+    "train": DataLoader(
+        BraTS2020Dataset(device=infer_device(), skip_slices=5, **TRAIN_DS_KWARGS),
+    ),
+    "val": DataLoader(
+        BraTS2020Dataset(device=infer_device(), skip_slices=5, **VAL_DS_KWARGS),
+    ),
 }
 trainer = UNetTrainer(
     model,


### PR DESCRIPTION
- Makes `BraTS2020Classes` to encapsulate labels and converters of labels
- Added `skip_slices` to `BraTS2020Dataset` to shrink MRI size
- Added `torchinfo` for its `summary` to debug why I'm running out of RAM
- Made training infer `torch.device` and skip training-time validation
- Fixed validation dataset to use `train=False`