### PR TITLE
Training with metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,4 @@ repos:
     rev: v2.2.4
     hooks:
       - id: codespell
-        exclude: requirements.txt
+        args: [--skip=requirements.txt]

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -136,11 +136,13 @@ class BraTS2020Dataset(Dataset):
         )
 
 
-TRAIN_DS_KWARGS = {
+# Has labels
+TRAIN_VAL_DS_KWARGS = {
     "data_folder_path": BRATS_2020_TRAINING_FOLDER,
     "mapping_csv_name": "name_mapping.csv",
 }
-VAL_DS_KWARGS = {
+# Has no labels
+TEST_DS_KWARGS = {
     "data_folder_path": BRATS_2020_VALIDATION_FOLDER,
     "mapping_csv_name": "name_mapping_validation_data.csv",
     "train": False,
@@ -148,11 +150,11 @@ VAL_DS_KWARGS = {
 
 
 def main() -> None:
-    train_ds = BraTS2020Dataset(**TRAIN_DS_KWARGS)
+    train_ds = BraTS2020Dataset(**TRAIN_VAL_DS_KWARGS)
     for images, targets in train_ds:  # noqa: B007
         _ = 0
-    val_ds = BraTS2020Dataset(**VAL_DS_KWARGS)
-    for images in val_ds:  # noqa: B007
+    test_ds = BraTS2020Dataset(**TEST_DS_KWARGS)
+    for images in test_ds:  # noqa: B007
         _ = 0
 
 

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -132,7 +132,7 @@ class BraTS2020Dataset(Dataset):
                 path=self.get_full_path(index, self.MASK_EXTENSION),
             )
         except FileNotFoundError:
-            # Exceptional case for BraTS20_Training_355
+            # Exceptional case for training data's BraTS20_Training_355
             image_folder = self.get_image_folder(index)
             files = [
                 i

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import torch
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, Subset
 
 from data import BRATS_2020_TRAINING_FOLDER, BRATS_2020_VALIDATION_FOLDER
 
@@ -134,6 +134,21 @@ class BraTS2020Dataset(Dataset):
             dtype=torch.get_default_dtype(),  # Match pytorch-3dunet internals
             device=self.device,
         )
+
+
+def split_train_val(
+    ds: Dataset,
+    batch_size: int,
+    fraction: float = 0.9,
+) -> tuple[Subset, Subset]:
+    """Split the input dataset into two based on a batch size and fraction."""
+    num_train = int(len(ds) / batch_size * fraction)
+    return tuple(
+        torch.utils.data.random_split(
+            dataset=ds,
+            lengths=(num_train, len(ds) - num_train),
+        ),
+    )
 
 
 # Has labels

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -39,7 +39,7 @@ model = UNet3D(
     final_sigmoid=True,
     f_maps=INITIAL_CONV_OUT_CHANNELS,
     num_groups=6,
-)
+).to(device=infer_device())
 # print_summary(model)
 data_loaders: dict[Literal["train", "val"], DataLoader] = {
     "train": DataLoader(

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -61,10 +61,11 @@ data_loaders: dict[Literal["train", "val"], DataLoader] = {
 }
 defeat_max_num_iters = max(len(data_loaders[split]) for split in data_loaders) + 1
 
+optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
 trainer = UNetTrainer(
     model,
-    optimizer=torch.optim.Adam(model.parameters(), lr=5e-4),
-    lr_scheduler=None,
+    optimizer=optimizer,
+    lr_scheduler=torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer),
     loss_criterion=BCEDiceLoss(alpha=1.0, beta=1.0),
     eval_criterion=MeanIoU(),
     loaders=data_loaders,

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -67,7 +67,7 @@ trainer = UNetTrainer(
     loss_criterion=BCEDiceLoss(alpha=1.0, beta=1.0),
     eval_criterion=MeanIoU(),
     loaders=data_loaders,
-    checkpoint_dir=str(ZOO_FOLDER / "logs"),
+    checkpoint_dir=str(ZOO_FOLDER),
     max_num_epochs=5,
     max_num_iterations=defeat_max_num_iters,
     tensorboard_formatter=DefaultTensorboardFormatter(),

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -17,7 +17,6 @@ MASK_COUNT = 3  # WT, TC, ET
 INITIAL_CONV_OUT_CHANNELS = 12
 SKIP_SLICES = 5
 BATCH_SIZE = 1
-TRAIN_VAL_SPLIT = 0.9  # * 100% training
 
 
 def infer_device() -> torch.device:
@@ -49,11 +48,7 @@ train_val_ds = BraTS2020Dataset(
     skip_slices=SKIP_SLICES,
     **TRAIN_VAL_DS_KWARGS,
 )
-train_ds, val_ds = split_train_val(
-    train_val_ds,
-    batch_size=BATCH_SIZE,
-    fraction=TRAIN_VAL_SPLIT,
-)
+train_ds, val_ds = split_train_val(train_val_ds, batch_size=BATCH_SIZE)
 
 data_loaders: dict[Literal["train", "val"], DataLoader] = {
     "train": DataLoader(train_ds, batch_size=BATCH_SIZE),

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -9,7 +9,7 @@ from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
 from torchinfo import summary
 
-from data.loaders import TRAIN_VAL_DS_KWARGS, BraTS2020Dataset
+from data.loaders import TRAIN_VAL_DS_KWARGS, BraTS2020Dataset, split_train_val
 from unet_zoo import ZOO_FOLDER
 
 NUM_SCANS_PER_EXAMPLE = len(BraTS2020Dataset.NONMASK_EXTENSIONS)
@@ -49,11 +49,12 @@ train_val_ds = BraTS2020Dataset(
     skip_slices=SKIP_SLICES,
     **TRAIN_VAL_DS_KWARGS,
 )
-num_train = int(len(train_val_ds) * TRAIN_VAL_SPLIT)
-train_ds, val_ds = torch.utils.data.random_split(
-    dataset=train_val_ds,
-    lengths=(num_train, len(train_val_ds) - num_train),
+train_ds, val_ds = split_train_val(
+    train_val_ds,
+    batch_size=BATCH_SIZE,
+    fraction=TRAIN_VAL_SPLIT,
 )
+
 data_loaders: dict[Literal["train", "val"], DataLoader] = {
     "train": DataLoader(train_ds, batch_size=BATCH_SIZE),
     "val": DataLoader(val_ds, batch_size=BATCH_SIZE),


### PR DESCRIPTION
This PR enables our training to survive cycles of training/validation.

Data loader:
- Fixed datasets in loader to have clear train, val, and test demarcations, and utilized in `train.py`
- Accommodated training data's `BraTS20_Training_355`, which has a different segmentation filename

Training:
- Cast our `model` to the inferred device
- Properly defeated max number of iterations with a formula, and not hardcoded number
- Fixed incorrect `checkpoint_dir`
- Using the required validation metrics and learning rate scheduler