### PR TITLE
Longer training

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,6 @@ repos:
     rev: v2.2.4
     hooks:
       - id: codespell
-        args: [--skip=requirements.txt]
+        args:
+          - --skip
+          - requirements.in,requirements.txt

--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ kaggle datasets download -p data/brats2020-training-validation-data \
     --unzip awsaf49/brats20-dataset-training-validation
 ```
 
+### TensorBoard
+
+#### Local Training
+
+Here is how you kick off TensorBoard:
+
+```shell
+tensorboard --logdir <path> --port 6006
+```
+
+Afterwards, go to the URL: http://localhost:6006/.
+
+#### Remote Training
+
+If training on a remote machine, on the remote machine:
+
+```shell
+tensorboard --logdir <path> --port 6006
+```
+
+Then on the local machine:
+
+```shell
+export SEG01=111.222.333.444
+ssh -N -f -L localhost:16006:localhost:6006 ubuntu@$SEG01
+```
+
+Afterwards, go to the URL: http://localhost:16006/.
+
 [1]: http://cs231n.stanford.edu/
 [3]: https://www.med.upenn.edu/cbica/brats/
 [4]: https://github.com/Kaggle/kaggle-api

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -17,6 +17,7 @@ MASK_COUNT = 3  # WT, TC, ET
 INITIAL_CONV_OUT_CHANNELS = 12
 SKIP_SLICES = 5
 BATCH_SIZE = 1
+NUM_EPOCHS = 5
 
 
 def infer_device() -> torch.device:
@@ -54,7 +55,9 @@ data_loaders: dict[Literal["train", "val"], DataLoader] = {
     "train": DataLoader(train_ds, batch_size=BATCH_SIZE),
     "val": DataLoader(val_ds, batch_size=BATCH_SIZE),
 }
-defeat_max_num_iters = max(len(data_loaders[split]) for split in data_loaders) + 1
+defeat_max_num_iters = (
+    NUM_EPOCHS * max(len(data_loaders[split]) for split in data_loaders) + 1
+)
 
 optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
 trainer = UNetTrainer(
@@ -65,7 +68,7 @@ trainer = UNetTrainer(
     eval_criterion=MeanIoU(),
     loaders=data_loaders,
     checkpoint_dir=str(ZOO_FOLDER),
-    max_num_epochs=5,
+    max_num_epochs=NUM_EPOCHS,
     max_num_iterations=defeat_max_num_iters,
     tensorboard_formatter=DefaultTensorboardFormatter(),
 )

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -14,10 +14,10 @@ from unet_zoo import ZOO_FOLDER
 
 NUM_SCANS_PER_EXAMPLE = len(BraTS2020Dataset.NONMASK_EXTENSIONS)
 MASK_COUNT = 3  # WT, TC, ET
-INITIAL_CONV_OUT_CHANNELS = 12
+INITIAL_CONV_OUT_CHANNELS = 18
 SKIP_SLICES = 5
 BATCH_SIZE = 1
-NUM_EPOCHS = 5
+NUM_EPOCHS = 10
 
 
 def infer_device() -> torch.device:
@@ -40,7 +40,7 @@ model = UNet3D(
     out_channels=MASK_COUNT,
     final_sigmoid=True,
     f_maps=INITIAL_CONV_OUT_CHANNELS,
-    num_groups=6,
+    num_groups=9,
 ).to(device=infer_device())
 # print_summary(model)
 


### PR DESCRIPTION
- Bumped up max epochs to 10, since both training-set and validation-set loss hadn't plateaued
- Increased model size to 18 conv1 out channels with 9 groups
- Added tutorial to `README.md` on TensorBoard
- Fixed `defeat_max_num_iters` to use epochs too