### PR TITLE
`BraTS2020Dataset` validations

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 import pandas as pd
 import torch
 from torch.utils.data import Dataset, Subset
+from tqdm import tqdm
 
 from data import BRATS_2020_TRAINING_FOLDER, BRATS_2020_VALIDATION_FOLDER
 
@@ -184,11 +185,15 @@ TEST_DS_KWARGS = {
 
 def main() -> None:
     train_ds = BraTS2020Dataset(**TRAIN_VAL_DS_KWARGS)
-    for images, targets in train_ds:  # noqa: B007
-        _ = 0
+    mins_maxes = []
+    for images, targets in tqdm(train_ds, desc="training dataset"):  # noqa: B007
+        mid_slice = targets[0, targets.shape[1] // 2]
+        mins_maxes.append((mid_slice.min(), mid_slice.max()))
+        _ = 0  # Debug here
+    _ = 0  # Debug here
     test_ds = BraTS2020Dataset(**TEST_DS_KWARGS)
-    for images in test_ds:  # noqa: B007
-        _ = 0
+    for images in tqdm(test_ds, desc="test dataset"):  # noqa: B007
+        _ = 0  # Debug here
 
 
 if __name__ == "__main__":

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -108,8 +108,10 @@ class BraTS2020Dataset(Dataset):
             raw_img = nib.load(path).dataobj[:, :, self.skip_slices : -self.skip_slices]
         return np.asarray(raw_img)
 
-    def __getitem__(self, index: int) -> tuple[torch.Tensor, ...]:
+    def __getitem__(self, index: int | slice) -> tuple[torch.Tensor, ...]:
         """Get (images, masks) if training, otherwise (images,)."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Dataset slicing is unimplemented.")
         raw_imgs = (
             self._load_nii_with_slicing(path)
             for path in (
@@ -117,8 +119,13 @@ class BraTS2020Dataset(Dataset):
                 for extension in self.NONMASK_EXTENSIONS
             )
         )
-        # Normalize to be in [0, 1]
-        img = np.stack((img - img.min()) / (img.max() - img.min()) for img in raw_imgs)
+        try:
+            # Normalize to be in [0, 1]
+            img = np.stack(
+                (img - img.min()) / (img.max() - img.min()) for img in raw_imgs
+            )
+        except KeyError as exc:
+            raise IndexError(f"Index {index} is not in the dataset.") from exc
         image_tensor = torch.as_tensor(
             # N x W x H x C to N x C x H x W
             np.moveaxis(img, (0, 1, 2, 3), (0, 3, 2, 1)),
@@ -185,10 +192,7 @@ TEST_DS_KWARGS = {
 
 def main() -> None:
     train_ds = BraTS2020Dataset(**TRAIN_VAL_DS_KWARGS)
-    mins_maxes = []
     for images, targets in tqdm(train_ds, desc="training dataset"):  # noqa: B007
-        mid_slice = targets[0, targets.shape[1] // 2]
-        mins_maxes.append((mid_slice.min(), mid_slice.max()))
         _ = 0  # Debug here
     _ = 0  # Debug here
     test_ds = BraTS2020Dataset(**TEST_DS_KWARGS)

--- a/requirements.in
+++ b/requirements.in
@@ -10,10 +10,12 @@ pydicom
 scikit-image
 scikit-learn
 seaborn
+tqdm
 
 # data
 kaggle  # Downloading datasets
 nibabel
+tqdm
 
 # unet_zoo
 git+https://github.com/wolny/pytorch-3dunet.git@1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -281,7 +281,9 @@ torch==2.0.1
 torchinfo==1.8.0
     # via -r requirements.in
 tqdm==4.65.0
-    # via kaggle
+    # via
+    #   -r requirements.in
+    #   kaggle
 traitlets==5.9.0
     # via
     #   ipython


### PR DESCRIPTION
- Adds `IndexError` if `index` is out-of bounds
- Adds `NotImplementedError` for if trying to slice the dataset
- Adds `tqdm` to the requirements files