### PR TITLE
`UNet2D` training compatibility

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -175,6 +175,7 @@ class BraTS2020MRISlicesDataset(IterableDataset):
         self,
         scans_ds: BraTS2020MRIScansDataset,
         slices_per_mri: int | None = None,
+        insert_z_dim: bool = True,
     ):
         """
         Initialize.
@@ -183,6 +184,8 @@ class BraTS2020MRISlicesDataset(IterableDataset):
             scans_ds: Dataset of MRI scans to wrap.
             slices_per_mri: Slices per MRI to use, leave as default of None to
                 infer from the 0th MRI scan.
+            insert_z_dim: Set True (default) to add a placeholder C dimension,
+                for compatibility with pytorch-3dunet's UNet2D training.
         """
         self._scans_ds = scans_ds
         if slices_per_mri is None:  # Infer
@@ -193,6 +196,7 @@ class BraTS2020MRISlicesDataset(IterableDataset):
         self._current_scans: tuple[torch.Tensor, ...] = self._scans_ds[
             self._coordinate[0]
         ]
+        self.insert_z_dim = insert_z_dim
 
     def __len__(self) -> int:
         return len(self._scans_ds) * self._slices_per_mri
@@ -205,6 +209,8 @@ class BraTS2020MRISlicesDataset(IterableDataset):
         if scan_index >= len(self._scans_ds):
             raise StopIteration
         slices = tuple(s[:, slice_index] for s in self._current_scans)
+        if self.insert_z_dim:
+            slices = tuple(s.unsqueeze(dim=-3) for s in slices)
         if slice_index + 1 == self._slices_per_mri:
             self._coordinate = scan_index + 1, 0
             self._current_scans = self._scans_ds[self._coordinate[0]]
@@ -257,7 +263,7 @@ def play_slices_ds() -> None:
         batch_size=1,
     )
     train_slices_ds = BraTS2020MRISlicesDataset(scans_ds=train_scans_ds)
-    data_loader = DataLoader(train_slices_ds, batch_size=10)
+    data_loader = DataLoader(train_slices_ds, batch_size=32)
     for images, targets in tqdm(data_loader, desc="training dataset"):  # noqa: B007
         _ = 0  # Debug here
     _ = 0  # Debug here

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -252,10 +252,12 @@ def play_scans_ds() -> None:
 
 
 def play_slices_ds() -> None:
-    slices_ds = BraTS2020MRISlicesDataset(
-        scans_ds=BraTS2020MRIScansDataset(**TRAIN_VAL_DS_KWARGS),
+    train_scans_ds, val_scans_ds = split_train_val(
+        BraTS2020MRIScansDataset(**TRAIN_VAL_DS_KWARGS),
+        batch_size=1,
     )
-    data_loader = DataLoader(slices_ds, batch_size=10)
+    train_slices_ds = BraTS2020MRISlicesDataset(scans_ds=train_scans_ds)
+    data_loader = DataLoader(train_slices_ds, batch_size=10)
     for images, targets in tqdm(data_loader, desc="training dataset"):  # noqa: B007
         _ = 0  # Debug here
     _ = 0  # Debug here

--- a/unet_zoo/predict.py
+++ b/unet_zoo/predict.py
@@ -3,14 +3,16 @@ from typing import Any
 import torch
 from pytorch3dunet.unet3d.model import UNet3D
 from pytorch3dunet.unet3d.utils import load_checkpoint
+from torch.utils.data import DataLoader
 
 from unet_zoo import CHECKPOINTS_FOLDER
 from unet_zoo.train import (
+    BATCH_SIZE,
     INITIAL_CONV_OUT_CHANNELS,
     MASK_COUNT,
     NUM_GROUPS,
     NUM_SCANS_PER_EXAMPLE,
-    get_train_val_data_loaders,
+    get_train_val_datasets,
 )
 from unet_zoo.utils import infer_device
 
@@ -30,8 +32,8 @@ def main() -> None:
     state_dict: dict[str, Any] = load_checkpoint(BEST_MODEL, model)  # noqa: F841
 
     model.eval()
-    data_loaders = get_train_val_data_loaders()
-    for images, targets in data_loaders["val"]:
+    val_ds = get_train_val_datasets()[1]
+    for images, targets in DataLoader(val_ds, batch_size=BATCH_SIZE):
         wt_labels, tc_labels, et_labels = (targets[0][i] for i in range(3))
         with torch.no_grad():
             wt_probs, tc_probs, et_probs = (

--- a/unet_zoo/predict.py
+++ b/unet_zoo/predict.py
@@ -12,7 +12,7 @@ from unet_zoo.train import (
     MASK_COUNT,
     NUM_GROUPS,
     NUM_SCANS_PER_EXAMPLE,
-    get_train_val_datasets,
+    get_train_val_scans_datasets,
 )
 from unet_zoo.utils import infer_device
 
@@ -32,7 +32,7 @@ def main() -> None:
     state_dict: dict[str, Any] = load_checkpoint(BEST_MODEL, model)  # noqa: F841
 
     model.eval()
-    val_ds = get_train_val_datasets()[1]
+    val_ds = get_train_val_scans_datasets()[1]
     for images, targets in DataLoader(val_ds, batch_size=BATCH_SIZE):
         wt_labels, tc_labels, et_labels = (targets[0][i] for i in range(3))
         with torch.no_grad():


### PR DESCRIPTION
- Added ability to insert a placeholder Z dimension into the slices dataset, for `pytorch-3dunet` compatibility
- Made `split_train_val` happen before `BraTS2020MRISlicesDataset` since PyTorch interprets it as a mapped dataset afterwards
- Fixed dataset factory to have batch size of 1 (since this matters for scans)