### PR TITLE
Resetting of `BraTS2020MRISlicesDataset` across iterations

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -249,9 +249,12 @@ TEST_DS_KWARGS = {
 
 def play_scans_ds() -> None:
     train_ds = BraTS2020MRIScansDataset(**TRAIN_VAL_DS_KWARGS)
-    for images, targets in tqdm(train_ds, desc="training dataset"):  # noqa: B007
-        _ = 0  # Debug here
+    data_loader = DataLoader(train_ds, batch_size=1)
+    for _ in range(2):  # Confirm can iterate over it 2+ times
+        for images, targets in tqdm(data_loader, desc="training dataset"):  # noqa: B007
+            _ = 0  # Debug here
     _ = 0  # Debug here
+
     test_ds = BraTS2020MRIScansDataset(**TEST_DS_KWARGS)
     for images in tqdm(test_ds, desc="test dataset"):  # noqa: B007
         _ = 0  # Debug here
@@ -264,8 +267,9 @@ def play_slices_ds() -> None:
     )
     train_slices_ds = BraTS2020MRISlicesDataset(scans_ds=train_scans_ds)
     data_loader = DataLoader(train_slices_ds, batch_size=32)
-    for images, targets in tqdm(data_loader, desc="training dataset"):  # noqa: B007
-        _ = 0  # Debug here
+    for _ in range(2):  # Confirm can iterate over it 2+ times
+        for images, targets in tqdm(data_loader, desc="training dataset"):  # noqa: B007
+            _ = 0  # Debug here
     _ = 0  # Debug here
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ torch
 
 # development
 git+https://github.com/miykael/gif_your_nifti.git
-imageio<2.28  # TODO: remove after https://github.com/miykael/gif_your_nifti/pull/13
+imageio
 ipython  # For PyCharm debugging
 mypy
 pip-tools

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -64,6 +64,7 @@ def main() -> None:
     defeat_max_num_iters = (
         NUM_EPOCHS * max(len(data_loaders[split]) for split in data_loaders) + 1
     )
+    log_after_iters = int(defeat_max_num_iters / 20)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
     trainer = UNetTrainer(
@@ -76,6 +77,8 @@ def main() -> None:
         checkpoint_dir=str(CHECKPOINTS_FOLDER),
         max_num_epochs=NUM_EPOCHS,
         max_num_iterations=defeat_max_num_iters,
+        validate_after_iters=2 * log_after_iters,
+        log_after_iters=log_after_iters,
         tensorboard_formatter=DefaultTensorboardFormatter(),
     )
     trainer.fit()


### PR DESCRIPTION
- Fixed slices dataset not resetting itself across iterations
    - Expanded play functions within `loader.py` to `assert` for this behavior
- Autocomputing the log and validate iteration period to 20X and 10X per training
    - With the slices dataset the defaults are too small
- Unpinned `imageio` after upstream PR's merge