### PR TITLE
Prediction summary visualization and seeded datasets

### DIFF
--- a/data/loaders.py
+++ b/data/loaders.py
@@ -55,7 +55,7 @@ class BraTS2020MRIScansDataset(Dataset):
     TARGET_COLUMN = "BraTS_2020_subject_ID"
     # flair = T2-weighted Fluid Attenuated Inversion Recovery (T2-FLAIR)
     # t1 = native T1-weighted (T1)
-    # t1ce = post-contrast T1-weighted (T1Gd)
+    # t1ce = post-contrast T1-weighted (T1Gd), ce means contrast enhanced
     # t2 = T2-weighted (T2)
     NONMASK_EXTENSIONS = ["_flair.nii", "_t1.nii", "_t1ce.nii", "_t2.nii"]
     MASK_EXTENSION = "_seg.nii"

--- a/data/loaders.py
+++ b/data/loaders.py
@@ -165,6 +165,9 @@ class BraTS2020MRIScansDataset(Dataset):
         )
 
 
+NUM_SCANS_PER_EXAMPLE = len(BraTS2020MRIScansDataset.NONMASK_EXTENSIONS)
+
+
 class BraTS2020MRISlicesDataset(IterableDataset):
     """
     Iterable-style dataset for BraTS 2020 MRI scan slices.

--- a/unet_zoo/predict.py
+++ b/unet_zoo/predict.py
@@ -1,5 +1,11 @@
 from typing import Any
 
+import matplotlib.artist
+import matplotlib.axes
+import matplotlib.gridspec as gridspec
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 from pytorch3dunet.unet3d.model import UNet3D
 from pytorch3dunet.unet3d.utils import load_checkpoint
@@ -14,11 +20,103 @@ from unet_zoo.train import (
     NUM_SCANS_PER_EXAMPLE,
     get_train_val_scans_datasets,
 )
-from unet_zoo.utils import infer_device
+from unet_zoo.utils import get_mask_middle, infer_device
 
 LAST_MODEL = CHECKPOINTS_FOLDER / "last_checkpoint.pytorch"
 BEST_MODEL = CHECKPOINTS_FOLDER / "best_checkpoint.pytorch"
 THRESHOLD = 0.33
+
+
+def make_summary_plot(
+    images: torch.Tensor,
+    actual_masks: torch.Tensor,
+    pred_masks: torch.Tensor,
+    scan_id: int | None = None,
+):
+    fig = plt.figure(figsize=(20, 10))
+    axes: list[matplotlib.axes.Axes] = []
+    wt_mask_middle = get_mask_middle(mask=actual_masks[0])
+    gs = gridspec.GridSpec(nrows=2, ncols=4, height_ratios=[1, 1.5])
+
+    # 1. Plot source MRIs
+    # NOTE: order matches BraTS2020MRIScansDataset.NONMASK_EXTENSIONS
+    for i, title in enumerate(("FLAIR", "T1", "T1 contrast", "T2")):
+        ax = fig.add_subplot(gs[0, i])
+        axes.append(ax)
+        ax_img = ax.imshow(images[i, wt_mask_middle], cmap="bone")
+        ax.set_title(title, fontsize=18, weight="bold", y=-0.2)
+        fig.colorbar(ax_img)
+
+    # 2. Plot segmentations
+    axes_masks = (fig.add_subplot(gs[1, :2]), actual_masks), (
+        fig.add_subplot(gs[1, 2:]),
+        pred_masks,
+    )
+    all_seg_ax_imgs: list[list] = [
+        [ax.imshow(mask[0, wt_mask_middle], cmap="summer") for ax, mask in axes_masks],
+        [
+            ax.imshow(
+                np.ma.masked_where(
+                    ~mask[1, wt_mask_middle].bool(),
+                    mask[1, wt_mask_middle],
+                ),
+                cmap="rainbow",
+                alpha=0.6,
+            )
+            for ax, mask in axes_masks
+            if mask.max() > 0
+        ],
+        [
+            ax.imshow(
+                np.ma.masked_where(
+                    ~mask[2, wt_mask_middle].bool(),
+                    mask[2, wt_mask_middle],
+                ),
+                cmap="winter",
+                alpha=0.6,
+            )
+            for ax, mask in axes_masks
+            if mask.max() > 0
+        ],
+    ]
+    patches = [
+        mpatches.Patch(
+            color=all_seg_ax_imgs[0][0].cmap(all_seg_ax_imgs[0][0].norm(value=0)),
+            label="Healthy",
+        ),
+        *(
+            mpatches.Patch(
+                color=seg_ax_imgs[0].cmap(seg_ax_imgs[0].norm(value=1)),
+                label=label,
+            )
+            for label, seg_ax_imgs in zip(
+                [
+                    "Non-Enhancing\nTumor Core",
+                    "Peritumoral Edema",
+                    "GD-Enhancing\nTumor",
+                ],
+                all_seg_ax_imgs,
+                strict=True,
+            )
+            if len(seg_ax_imgs) > 0
+        ),
+    ]
+    plt.legend(
+        handles=patches,
+        bbox_to_anchor=(1.35, 0.2, 0.5, 0.5),
+        loc="upper right",
+        fontsize="xx-large",
+        title_fontsize=18,
+        framealpha=0.0,
+    )
+    for ax_ in (*axes, *(ax for ax, _ in axes_masks)):
+        ax_.set_axis_off()
+    scan_id = "" if scan_id is None else f"{scan_id} "
+    plt.suptitle(
+        f"MRI Scan {scan_id}at Slice {wt_mask_middle} | Target Mask - Actual Mask",
+        fontsize=20,
+        weight="bold",
+    )
 
 
 def main() -> None:
@@ -34,11 +132,10 @@ def main() -> None:
     model.eval()
     val_ds = get_train_val_scans_datasets()[1]
     for images, targets in DataLoader(val_ds, batch_size=BATCH_SIZE):
-        wt_labels, tc_labels, et_labels = (targets[0][i] for i in range(3))
         with torch.no_grad():
-            wt_probs, tc_probs, et_probs = (
-                (model(images)[0] > THRESHOLD)[i] for i in range(3)
-            )
+            preds = model(images)[0] > THRESHOLD
+        make_summary_plot(images=images[0], actual_masks=targets[0], pred_masks=preds)
+        _ = 0
 
 
 if __name__ == "__main__":

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -9,7 +9,7 @@ from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
 from torchinfo import summary
 
-from data.loaders import TRAIN_VAL_DS_KWARGS, BraTS2020MRIScansDataset, split_train_val
+from data.loaders import TRAIN_VAL_DS_KWARGS, BraTS2020MRIScansDataset
 from unet_zoo import CHECKPOINTS_FOLDER
 from unet_zoo.utils import infer_device
 
@@ -33,14 +33,13 @@ def print_summary(
 
 def get_train_val_scans_datasets(
     skip_slices: int = SKIP_SLICES,
-    batch_size: int = 1,
 ) -> tuple[BraTS2020MRIScansDataset, BraTS2020MRIScansDataset]:
     train_val_ds = BraTS2020MRIScansDataset(
         device=infer_device(),
         skip_slices=skip_slices,
         **TRAIN_VAL_DS_KWARGS,
     )
-    return split_train_val(train_val_ds, batch_size=batch_size)
+    return tuple(torch.utils.data.random_split(train_val_ds, lengths=(0.9, 0.1)))
 
 
 def main() -> None:

--- a/unet_zoo/train.py
+++ b/unet_zoo/train.py
@@ -7,13 +7,16 @@ from pytorch3dunet.unet3d.model import UNet3D
 from pytorch3dunet.unet3d.trainer import UNetTrainer
 from pytorch3dunet.unet3d.utils import DefaultTensorboardFormatter
 from torch.utils.data import DataLoader
-from torchinfo import summary
 
-from data.loaders import TRAIN_VAL_DS_KWARGS, BraTS2020MRIScansDataset, make_generator
+from data.loaders import (
+    NUM_SCANS_PER_EXAMPLE,
+    TRAIN_VAL_DS_KWARGS,
+    BraTS2020MRIScansDataset,
+    make_generator,
+)
 from unet_zoo import CHECKPOINTS_FOLDER
-from unet_zoo.utils import infer_device
+from unet_zoo.utils import infer_device, print_model_summary  # noqa: F401
 
-NUM_SCANS_PER_EXAMPLE = len(BraTS2020MRIScansDataset.NONMASK_EXTENSIONS)
 MASK_COUNT = 3  # WT, TC, ET
 INITIAL_CONV_OUT_CHANNELS = 18
 NUM_GROUPS = 9
@@ -21,15 +24,6 @@ SKIP_SLICES = 5
 BATCH_SIZE = 1
 NUM_EPOCHS = 10
 GENERATOR = make_generator(42)
-
-
-def print_summary(
-    model: torch.nn.Module,
-    skip_slices: int = SKIP_SLICES,
-    batch_size: int = BATCH_SIZE,
-) -> None:
-    num_slices = 155 - 2 * skip_slices
-    summary(model, input_size=(batch_size, NUM_SCANS_PER_EXAMPLE, num_slices, 240, 240))
 
 
 def get_train_val_scans_datasets(
@@ -60,7 +54,7 @@ def main() -> None:
         f_maps=INITIAL_CONV_OUT_CHANNELS,
         num_groups=NUM_GROUPS,
     ).to(device=infer_device())
-    # print_summary(model)
+    # print_model_summary(model)
 
     data_loaders: dict[Literal["train", "val"], DataLoader] = {
         name: DataLoader(ds, batch_size=BATCH_SIZE)

--- a/unet_zoo/utils.py
+++ b/unet_zoo/utils.py
@@ -1,7 +1,32 @@
 import torch
+from torchinfo import summary
+
+from data.loaders import NUM_SCANS_PER_EXAMPLE
 
 
 def infer_device() -> torch.device:
     if torch.cuda.is_available():
         return torch.device("cuda")  # Current CUDA device
     return torch.device("cpu")
+
+
+def print_model_summary(
+    model: torch.nn.Module,
+    skip_slices: int = 0,
+    batch_size: int = 1,
+) -> None:
+    num_slices = 155 - 2 * skip_slices
+    summary(model, input_size=(batch_size, NUM_SCANS_PER_EXAMPLE, num_slices, 240, 240))
+
+
+def get_mask_middle(mask: torch.Tensor) -> int:
+    """Get the middle slice of a binary MRI mask."""
+    if len(mask.shape) != 3:
+        raise ValueError(f"Unexpected mask shape {mask.shape}.")
+    first, last = None, None
+    for i, slice_has_mask in enumerate(mask.amax(dim=(1, 2))):
+        if first is None and slice_has_mask > 0:
+            first = i
+        if first is not None and last is None and slice_has_mask == 0 and i > 0:
+            last = i - 1
+    return (first + last) // 2


### PR DESCRIPTION
- Adds `predict.make_summary_plot` to produce summary plots at the center slice of a WT segmentation
    - Uses `get_mask_middle` to calculate the center slice of the WT mask
- Removes `split_train_val` in favor of direct `torch.utils.data.random_split`
- Adds `make_generator` helper to enable seeding by making a `torch.Generator`
- Reorders helper constants/functions for simpler `train`/`predict` scripts